### PR TITLE
implements the ltcpp lexer using ranges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 *.app
 
 build/*
+.vscode/*

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -80,7 +80,7 @@ function(build_impl target libraries)
 
    foreach(i ${libraries})
       message(STATUS "Linking ${i} with ${target}")
-      target_link_libraries("${target}" PUBLIC ${i})
+      target_link_libraries("${target}" PRIVATE ${i})
    endforeach()
    add_compile_options(-DRANGES_DEEP_STL_INTEGRATION=1)
 endfunction()

--- a/conan/remotes.txt
+++ b/conan/remotes.txt
@@ -1,3 +1,2 @@
 bincrafters https://api.bintray.com/conan/bincrafters/public-conan
-catchorg https://api.bintray.com/conan/catchorg/Catch2 
-range-v3 https://api.bintray.com/conan/range-v3/range-v3 
+catchorg https://api.bintray.com/conan/catchorg/Catch2

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,11 +17,11 @@ from conans import ConanFile, CMake, RunEnvironment, tools
 import os
 
 class Ltcpp(ConanFile):
-   name = "amcpp-gp2"
+   name = "ltcpp"
    version = "1.0"
    settings = "os", "compiler", "arch", "build_type"
    generators = "cmake", "cmake_paths", "virtualrunenv"
-   requires = "gsl_microsoft/[>=1.0.0]@bincrafters/stable", "range-v3/1.0.0@cjdb/stable", "expected-lite/0.2.0@cjdb/stable"
+   requires = "gsl_microsoft/[>=1.0.0]@bincrafters/stable", "range-v3/1.0.0@cjdb/stable"
    exports_sources = "CMakeLists.txt", ".clang*", "test/*", "src/*", "cmake/*"
    no_copy_source = True
 

--- a/include/ltcpp/consume_istream_while.hpp
+++ b/include/ltcpp/consume_istream_while.hpp
@@ -28,9 +28,13 @@ namespace ltcpp {
          {
             auto sequence = ranges::istream_range<char>(in)
                           | ranges::view::take_while(std::move(pred))
-                          | ranges::to_<std::string>();
-            if (in) {
+                          | ranges::to<std::string>();
+            if (in or in.eof()) {
+               auto const was_eof = in.eof();
                in.unget(); // take_while consumes an extra character
+               if (was_eof) {
+                  in.clear();
+               }
             }
             return sequence;
          }

--- a/include/ltcpp/consume_istream_while.hpp
+++ b/include/ltcpp/consume_istream_while.hpp
@@ -1,0 +1,42 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <istream>
+#include <range/v3/istream_range.hpp>
+#include <range/v3/view/take_while.hpp>
+#include <range/v3/to_container.hpp>
+#include <string>
+#include <utility>
+
+namespace ltcpp {
+   namespace detail_consume_istream_while_fn {
+      struct consume_istream_while_fn {
+         template<class F>
+         std::string operator()(std::istream& in, F pred) const
+         {
+            auto sequence = ranges::istream_range<char>(in)
+                          | ranges::view::take_while(std::move(pred))
+                          | ranges::to_<std::string>();
+            if (in) {
+               in.unget(); // take_while consumes an extra character
+            }
+            return sequence;
+         }
+      };
+   } // namespace detail_consume_istream_while_fn
+
+   inline constexpr auto consume_istream_while =
+      detail_consume_istream_while_fn::consume_istream_while_fn{};
+} // namespace ltcpp

--- a/include/ltcpp/irregular_transform.hpp
+++ b/include/ltcpp/irregular_transform.hpp
@@ -21,8 +21,8 @@
 #include <utility>
 
 namespace ltcpp {
-   inline auto irregular_transform = [](auto f){
-      return ranges::view::for_each([f=std::move(f)](auto&& r){
+   inline auto irregular_transform = [](auto&& f) {
+      return ranges::view::for_each([f=std::forward<decltype(f)>(f)](auto&& r) {
          return ranges::view::single(f(std::forward<decltype(r)>(r)));
       });
    };

--- a/include/ltcpp/irregular_transform.hpp
+++ b/include/ltcpp/irregular_transform.hpp
@@ -13,17 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef LTCPP_LEXER_DETAIL_SCAN_STRING_LITERAL_HPP
-#define LTCPP_LEXER_DETAIL_SCAN_STRING_LITERAL_HPP
+#ifndef LTCPP_IRREGULAR_TRANSFORM_HPP
+#define LTCPP_IRREGULAR_TRANSFORM_HPP
 
-#include "ltcpp/lexer/token.hpp"
-#include "ltcpp/source_coordinate.hpp"
-#include <istream>
+#include <range/v3/view/for_each.hpp>
+#include <range/v3/view/single.hpp>
+#include <utility>
 
-namespace ltcpp::detail_lexer {
-   /// \brief Scans a string literal.
-   ///
-   token scan_string_literal(std::istream& in, source_coordinate cursor) noexcept;
-} // namespace ltcpp::detail_lexer
-
-#endif // LTCPP_LEXER_DETAIL_SCAN_STRING_LITERAL_HPP
+namespace ltcpp {
+   inline auto irregular_transform = [](auto f){
+      return ranges::view::for_each([f=std::move(f)](auto&& r){
+         return ranges::view::single(f(std::forward<decltype(r)>(r)));
+      });
+   };
+} // namespace ltcpp
+#endif // LTCPP_IRREGULAR_TRANSFORM_HPP

--- a/include/ltcpp/lexer/detail/scan_symbol.hpp
+++ b/include/ltcpp/lexer/detail/scan_symbol.hpp
@@ -21,7 +21,7 @@
 #include <istream>
 
 namespace ltcpp::detail_lexer {
-   token scan_symbol(std::istream& in, char current, source_coordinate cursor) noexcept;
+   token scan_symbol(std::istream& in, source_coordinate cursor) noexcept(false);
 } // namespace ltcpp::detail_lexer
 
 #endif // LTCPP_LEXER_DETAIL_SCAN_STRING_SYMBOL_HPP

--- a/include/ltcpp/lexer/detail/scan_whitespace.hpp
+++ b/include/ltcpp/lexer/detail/scan_whitespace.hpp
@@ -20,6 +20,7 @@
 #include "ltcpp/source_coordinate.hpp"
 #include "ltcpp/source_coordinate_range.hpp"
 #include <istream>
+#include "tl/expected.hpp"
 #include <utility>
 
 namespace ltcpp::detail_lexer {

--- a/include/ltcpp/lexer/lexer.hpp
+++ b/include/ltcpp/lexer/lexer.hpp
@@ -31,6 +31,66 @@ namespace ltcpp {
    ///
    token
    generate_token(std::istream& in, reporter& report, source_coordinate cursor) noexcept(false);
+
+   class lexer_view {
+      class default_sentinel_t {}; // public-facing, can't use ranges...
+      class [[nodiscard]] lexer_iterator {
+      public:
+         using difference_type = std::intmax_t;
+
+         lexer_iterator() = default;
+
+         explicit lexer_iterator(std::istream* in, reporter* report) noexcept
+            : in_{in}
+            , report_{report}
+         {}
+
+         token operator*() noexcept(false)
+         {
+            auto result = ltcpp::generate_token(*in_, *report_, cursor_);
+            cursor_ = result.cursor_range().end;
+            return result;
+         }
+
+         lexer_iterator& operator++() noexcept
+         { return *this; }
+
+         lexer_iterator& operator++(int) noexcept
+         { return *this; }
+
+         friend bool operator==(lexer_iterator const& i, default_sentinel_t) noexcept
+         { return not i.in_->good(); }
+
+         friend bool operator==(default_sentinel_t s, lexer_iterator const& i) noexcept
+         { return i == s; }
+
+         friend bool operator!=(lexer_iterator const& i, default_sentinel_t s) noexcept
+         { return not (i == s); }
+
+         friend bool operator!=(default_sentinel_t s, lexer_iterator const& i) noexcept
+         { return not (s == i); }
+      private:
+         std::istream* in_;
+         reporter* report_;
+         source_coordinate cursor_;
+      };
+   public:
+      lexer_view() = default;
+
+      explicit lexer_view(std::istream& in, reporter& report) noexcept
+         : in_{std::addressof(in)}
+         , report_{std::addressof(report)}
+      { in.unsetf(std::ios_base::skipws); }
+
+      lexer_iterator begin() noexcept
+      { return lexer_iterator{in_, report_}; }
+
+      default_sentinel_t end() noexcept
+      { return {}; }
+   private:
+      std::istream* in_ = nullptr;
+      reporter* report_ = nullptr;
+   };
 } // namespace ltcpp
 
 #endif // LTCPP_LEXER_LEXER_HPP

--- a/include/ltcpp/lexer/token.hpp
+++ b/include/ltcpp/lexer/token.hpp
@@ -17,6 +17,7 @@
 #define LTCPP_LEXER_TOKEN_HPP
 
 #include "ltcpp/source_coordinate.hpp"
+#include "ltcpp/source_coordinate_range.hpp"
 #include <ostream>
 #include <string>
 #include <tuple>
@@ -241,7 +242,7 @@ namespace ltcpp {
          source_coordinate end)
          : kind_{kind}
          , spelling_{std::move(spelling)}
-         , position_{begin, end}
+         , cursor_range_{begin, end}
       {}
 
       token_kind kind() const noexcept
@@ -250,8 +251,8 @@ namespace ltcpp {
       std::string_view spelling() const noexcept
       { return spelling_; }
 
-      source_coordinate_range position() const noexcept
-      { return position_; }
+      source_coordinate_range cursor_range() const noexcept
+      { return cursor_range_; }
 
       friend bool operator==(token const& a, token const& b) noexcept
       {
@@ -267,7 +268,7 @@ namespace ltcpp {
    private:
       token_kind kind_;
       std::string spelling_;
-      source_coordinate_range position_;
+      source_coordinate_range cursor_range_;
    };
 
    token make_token(std::string lexeme, source_coordinate cursor_begin) noexcept;

--- a/include/ltcpp/source_coordinate.hpp
+++ b/include/ltcpp/source_coordinate.hpp
@@ -37,9 +37,9 @@ namespace ltcpp {
       /// \brief Initialises the column value with the column parameter and initialises the line
       ///        value with the line parameter.
       ///
-      constexpr explicit source_coordinate(column_type const column, line_type const line) noexcept
-         : column_{column}
-         , line_{line}
+      constexpr explicit source_coordinate(line_type const line, column_type const column) noexcept
+         : line_{line}
+         , column_{column}
       {}
 
       /// \brief Returns the column value.
@@ -98,6 +98,7 @@ namespace ltcpp {
       source_coordinate shift(source_coordinate const x, source_coordinate const y) noexcept
       {
          return source_coordinate{
+            line_type{x.line() + y.line()},
             column_type{
                  line_type{0}   == y.line()   ? x.column() + y.column()
                : column_type{0} <  y.column() ? y.column()
@@ -106,8 +107,8 @@ namespace ltcpp {
          };
       }
    private:
-      column_type column_{1};
       line_type line_{1};
+      column_type column_{1};
    };
 } // namespace ltcpp
 

--- a/include/ltcpp/source_coordinate.hpp
+++ b/include/ltcpp/source_coordinate.hpp
@@ -22,7 +22,7 @@
 #include <tuple>
 
 namespace ltcpp {
-   class source_coordinate {
+   class [[nodiscard]] source_coordinate {
       struct column_tag {};
       struct line_tag {};
    public:

--- a/include/ltcpp/utility/peek.hpp
+++ b/include/ltcpp/utility/peek.hpp
@@ -1,0 +1,45 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LTCPP_UTILITY_PEEK_HPP
+#define LTCPP_UTILITY_PEEK_HPP
+
+#include <istream>
+#include <optional>
+
+namespace ltcpp {
+   namespace detail_peek {
+      struct peek_fn {
+         template<class CharT, class Traits>
+         std::optional<CharT> operator()(std::basic_istream<CharT, Traits>& in) const
+         {
+            if (in) {
+               if (auto c = in.peek(); in.good()) {
+                  return static_cast<CharT>(c);
+               }
+               else {
+                  in.clear();
+               }
+            }
+
+            return {};
+         }
+      };
+   } // namespace detail_peek
+
+   inline constexpr auto peek = detail_peek::peek_fn{};
+} // namespace ltcpp
+
+#endif // LTCPP_UTILITY_PEEK_HPP

--- a/source/lexer/lexer.cpp
+++ b/source/lexer/lexer.cpp
@@ -1,0 +1,103 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "cjdb/cctype/isalpha.hpp"
+#include "cjdb/cctype/isdigit.hpp"
+#include <istream>
+#include <gsl/gsl>
+#include "ltcpp/lexer/detail/scan_identifier.hpp"
+#include "ltcpp/lexer/detail/scan_number.hpp"
+#include "ltcpp/lexer/detail/scan_string_literal.hpp"
+#include "ltcpp/lexer/detail/scan_symbol.hpp"
+#include "ltcpp/lexer/detail/scan_whitespace.hpp"
+#include "ltcpp/lexer/lexer.hpp"
+#include "ltcpp/reporter.hpp"
+#include "ltcpp/source_coordinate.hpp"
+#include "ltcpp/lexer/token.hpp"
+
+namespace {
+   using ltcpp::token, ltcpp::token_kind, ltcpp::reporter, ltcpp::source_coordinate;
+   using ltcpp::pass;
+   namespace lexer = ltcpp::detail_lexer;
+
+   void check_for_error(reporter& report, token const& t) noexcept(false)
+   {
+      if (t.kind() == token_kind::exponent_lacking_digit) {
+         report.error(pass::lexical, t.position().begin,
+            "floating-point exponent lacking digits: \"", t.spelling(), "\".");
+      }
+      else if (t.kind() == token_kind::too_many_radix_points) {
+         report.error(pass::lexical, t.position().begin,
+            "too many radix points in floating-point literal: \"", t.spelling(), "\".");
+      }
+      else if (t.kind() == ltcpp::token_kind::unterminated_string_literal) {
+         report.error(pass::lexical, t.position().end,
+            "unterminated string literal: \"", t.spelling(), "\".");
+      }
+      else {
+         return;
+      }
+   }
+
+   /// \brief
+   ///
+   token scan_token(std::istream& in, reporter& report, source_coordinate const cursor,
+      bool const unterminated_comment) noexcept(false)
+   {
+      if (auto const peek = static_cast<char>(in.peek()); cjdb::isalpha(peek)) {
+         return lexer::scan_identifier(in, cursor);
+      }
+      else if (cjdb::isdigit(peek)) {
+         auto result = lexer::scan_number(in, cursor);
+         check_for_error(report, result);
+         return result;
+      }
+      else if (peek == '.') {
+         auto result = lexer::possibly_float(in, cursor);
+         check_for_error(report, result);
+         return result;
+      }
+      else if (peek == '"') {
+         auto result = lexer::scan_string_literal(in, cursor);
+         check_for_error(report, result);
+         return result;
+      }
+      else if (auto current = '\0'; in.get(current)) {
+         return lexer::scan_symbol(in, current, cursor);
+      }
+      else if (in.eof()) {
+         if (unterminated_comment) {
+            report.error(pass::lexical, cursor, "unterminated multi-line comment.");
+         }
+
+         constexpr auto eof_spelling = "$";
+         return token{token_kind::eof, eof_spelling, cursor, cursor};
+      }
+      else {
+         throw std::runtime_error{"Unable to read character from stream."};
+      }
+   }
+} // namespace
+
+namespace ltcpp {
+   ///
+   ///
+   token generate_token(std::istream& in, reporter& report, source_coordinate const cursor) noexcept(false)
+   {
+      auto const cursor_result = detail_lexer::scan_whitespace_like(in, cursor);
+      auto const token_result = ::scan_token(in, report, cursor_result.first, cursor_result.second);
+      return token_result;
+   }
+} // namespace ltcpp

--- a/source/lexer/lexer.cpp
+++ b/source/lexer/lexer.cpp
@@ -28,12 +28,14 @@
 #include "ltcpp/lexer/token.hpp"
 #include <string_view>
 
+#include "ltcpp/utility/peek.hpp"
+
 namespace {
    using ltcpp::token, ltcpp::token_kind, ltcpp::reporter, ltcpp::source_coordinate;
    using ltcpp::pass;
    namespace lexer = ltcpp::detail_lexer;
 
-   void check_for_error(reporter& report, token const& t) noexcept(false)
+   void check_for_error(reporter& report, token const& t) noexcept
    {
       using namespace std::string_view_literals;
       auto const message =
@@ -43,69 +45,97 @@ namespace {
        : t.kind() == token_kind::unknown_token               ? "unknown token: \""sv
                                                              : ""sv;
       if (not empty(message)) {
-         report.error(pass::lexical, t.position().begin, message, t.spelling(), "\".");
+         report.error(pass::lexical, t.cursor_range().begin, message, t.spelling(), "\".");
       }
       else {
          return;
       }
    }
 
-   /// \brief
+   using scan_function = token(&)(std::istream&, source_coordinate) noexcept(false);
+   token guarded_scan(scan_function scanner, std::istream& in, source_coordinate cursor,
+      reporter& report) noexcept(false)
+   {
+      auto result = scanner(in, cursor);
+      check_for_error(report, result);
+      return result;
+   }
+
+   token scan_non_eof(std::istream& in, reporter& report, source_coordinate cursor, char next)
+   noexcept(false)
+   {
+      if (cjdb::isalpha(next)) {
+         return lexer::scan_identifier(in, cursor);
+      }
+      else if (cjdb::isdigit(next)) {
+         return guarded_scan(lexer::scan_number, in, cursor, report);
+      }
+      else if (next == '.') {
+         return guarded_scan(lexer::possibly_float, in, cursor, report);
+      }
+      else if (next == '"') {
+         return guarded_scan(lexer::scan_string_literal, in, cursor, report);
+      }
+      else {
+         return guarded_scan(lexer::scan_symbol, in, cursor, report);
+      }
+   }
+
+   token scan_eof(std::istream& in, reporter& report,
+      tl::expected<source_coordinate, lexer::unterminated_comment_error> cursor_result) noexcept(false)
+   {
+      in.get();
+      assert(in.eof());
+
+      auto eof_cursor = source_coordinate{};
+
+      if (cursor_result) {
+         eof_cursor = *cursor_result;
+      }
+      else {
+         auto const error = cursor_result.error();
+         report.error(pass::lexical, error.begin, "unterminated multi-line comment.");
+         eof_cursor = error.end;
+      }
+
+      constexpr auto eof_spelling = "$";
+      return token{token_kind::eof, eof_spelling, eof_cursor, eof_cursor};
+   }
+
+   /// \brief Extracts the next token from the input stream.
+   /// \param istream The stream to extract from.
+   /// \param report The warning and error reporter.
+   /// \param cursor_result In the event of an unterminated multi-line comment, cursor_result will
+   ///        contain both the position of the cursor at the start of the comment and at the end of
+   ///        the comment. Otherwise, it contains the coordinate to the first non-whitespace
+   ///        character in the file.
+   /// \returns A token that contains information about the token's kind, the token's position in
+   ///          the source file, and how it is spelt in the source file.
+   /// \throws std::runtime_error if a character cannot be read from the stream, and
+   ///         `in.eof() == false`.
    ///
    token scan_token(std::istream& in, reporter& report,
       tl::expected<source_coordinate, lexer::unterminated_comment_error> cursor_result) noexcept(false)
    {
-      if (auto const peek = static_cast<char>(in.peek()); cjdb::isalpha(peek)) {
+      if (auto const next = ltcpp::peek(in); next) {
          assert(cursor_result);
-         return lexer::scan_identifier(in, *cursor_result);
-      }
-      else if (cjdb::isdigit(peek)) {
-         assert(cursor_result);
-         auto result = lexer::scan_number(in, *cursor_result);
-         check_for_error(report, result);
-         return result;
-      }
-      else if (peek == '.') {
-         assert(cursor_result);
-         auto result = lexer::possibly_float(in, *cursor_result);
-         check_for_error(report, result);
-         return result;
-      }
-      else if (peek == '"') {
-         assert(cursor_result);
-         auto result = lexer::scan_string_literal(in, *cursor_result);
-         check_for_error(report, result);
-         return result;
-      }
-      else if (auto current = '\0'; in.get(current)) {
-         assert(cursor_result);
-         auto result = lexer::scan_symbol(in, current, *cursor_result);
-         check_for_error(report, result);
-         return result;
-      }
-      else if (in.eof()) {
-         auto eof_cursor = source_coordinate{};
-
-         if (cursor_result) {
-            eof_cursor = *cursor_result;
-         }
-         else {
-            auto const error = cursor_result.error();
-            report.error(pass::lexical, error.begin, "unterminated multi-line comment.");
-            eof_cursor = error.end;
-         }
-
-         constexpr auto eof_spelling = "$";
-         return token{token_kind::eof, eof_spelling, eof_cursor, eof_cursor};
+         return scan_non_eof(in, report, *cursor_result, *next);
       }
       else {
-         throw std::runtime_error{"Unable to read character from stream."};
+         return scan_eof(in, report, std::move(cursor_result));
       }
    }
 } // namespace
 
 namespace ltcpp {
-   ///
+   /// \brief Strips all whitespace and comments, and extracts the next token from an input stream.
+   /// \param istream The stream to extract from.
+   /// \param report The warning and error reporter.
+   /// \param cursor The position in the source file that we are currently reading from.
+   /// \returns A token that contains information about the token's kind, the token's position in
+   ///          the source file, and how it is spelt in the source file.
+   /// \throws std::runtime_error if a character cannot be read from the stream, and
+   ///         `in.eof() == false`.
    ///
    token generate_token(std::istream& in, reporter& report, source_coordinate const cursor) noexcept(false)
    {

--- a/source/lexer/lexer.cpp
+++ b/source/lexer/lexer.cpp
@@ -45,7 +45,7 @@ namespace {
        : t.kind() == token_kind::unknown_token               ? "unknown token: \""sv
                                                              : ""sv;
       if (not empty(message)) {
-         report.error(pass::lexical, t.cursor_range().begin, message, t.spelling(), "\".");
+         report.error(pass::lexical, t.cursor_range().begin(), message, t.spelling(), "\".");
       }
       else {
          return;
@@ -70,9 +70,6 @@ namespace {
       else if (cjdb::isdigit(next)) {
          return guarded_scan(lexer::scan_number, in, cursor, report);
       }
-      else if (next == '.') {
-         return guarded_scan(lexer::possibly_float, in, cursor, report);
-      }
       else if (next == '"') {
          return guarded_scan(lexer::scan_string_literal, in, cursor, report);
       }
@@ -94,8 +91,8 @@ namespace {
       }
       else {
          auto const error = cursor_result.error();
-         report.error(pass::lexical, error.begin, "unterminated multi-line comment.");
-         eof_cursor = error.end;
+         report.error(pass::lexical, error.begin(), "unterminated multi-line comment.");
+         eof_cursor = error.end();
       }
 
       constexpr auto eof_spelling = "$";

--- a/source/lexer/scan_identifier.cpp
+++ b/source/lexer/scan_identifier.cpp
@@ -13,17 +13,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef LTCPP_LEXER_DETAIL_SCAN_STRING_LITERAL_HPP
-#define LTCPP_LEXER_DETAIL_SCAN_STRING_LITERAL_HPP
-
+#include <cctype>
+#include <istream>
+#include "ltcpp/lexer/detail/scan_identifier.hpp"
 #include "ltcpp/lexer/token.hpp"
 #include "ltcpp/source_coordinate.hpp"
-#include <istream>
+#include "ltcpp/consume_istream_while.hpp"
+#include <utility>
 
 namespace ltcpp::detail_lexer {
-   /// \brief Scans a string literal.
+   /// \brief
+   /// \param in
+   /// \param cursor The position in the source file where the identifier begins.
+   /// \returns
    ///
-   token scan_string_literal(std::istream& in, source_coordinate cursor) noexcept;
+   token scan_identifier(std::istream& in, source_coordinate const cursor) noexcept
+   {
+      constexpr auto is_identifier_char = [](unsigned char const x) constexpr noexcept {
+         return std::isalnum(x) or x == '_';
+      };
+      auto identifier = ltcpp::consume_istream_while(in, is_identifier_char);
+      return ltcpp::make_token(std::move(identifier), cursor);
+   }
 } // namespace ltcpp::detail_lexer
-
-#endif // LTCPP_LEXER_DETAIL_SCAN_STRING_LITERAL_HPP

--- a/source/lexer/scan_number.cpp
+++ b/source/lexer/scan_number.cpp
@@ -21,7 +21,11 @@
 #include "ltcpp/consume_istream_while.hpp"
 #include <string>
 
+#include "ltcpp/utility/peek.hpp"
+
 namespace {
+   using ltcpp::peek;
+
    /// \brief
    /// \param in
    /// \param cursor The position in the source file where the identifier begins.
@@ -29,11 +33,11 @@ namespace {
    ///
    std::string scan_floating_exponent(std::istream& in) noexcept(false)
    {
-      if (auto c = in.peek(); std::toupper(c) == 'E') {
+      if (auto next = peek(in); next and std::toupper(*next) == 'E') {
          auto exponent = std::string{static_cast<char>(in.get())};
 
          // an exponent may have one '+' or '-' after the 'E'
-         if (c = in.peek(); c == '+' or c == '-') {
+         if (next = peek(in); next and (*next == '+' or *next == '-')) {
             exponent += static_cast<char>(in.get());
          }
 
@@ -70,7 +74,7 @@ namespace ltcpp::detail_lexer {
    token scan_number(std::istream& in, source_coordinate const cursor) noexcept
    {
       auto number = ltcpp::consume_istream_while(in, cjdb::isdigit);
-      if (auto peek = in.peek(); peek == '.' or peek == 'e' or peek == 'E') {
+      if (auto next = peek(in); next and (*next == '.' or *next == 'e' or *next == 'E')) {
          return ::scan_floating(in, std::move(number), cursor);
       }
       else {
@@ -83,7 +87,7 @@ namespace ltcpp::detail_lexer {
    token possibly_float(std::istream& in, source_coordinate const cursor) noexcept
    {
       auto dot = static_cast<char>(in.get());
-      if (in and std::isdigit(in.peek())) {
+      if (auto next = peek(in); next and std::isdigit(*next)) {
          return ::scan_floating(in, std::string{dot}, cursor);
       }
       else {

--- a/source/lexer/scan_number.cpp
+++ b/source/lexer/scan_number.cpp
@@ -1,0 +1,93 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <cctype>
+#include <cjdb/cctype/isdigit.hpp>
+#include <istream>
+#include "ltcpp/lexer/detail/scan_number.hpp"
+#include "ltcpp/lexer/token.hpp"
+#include "ltcpp/consume_istream_while.hpp"
+#include <string>
+
+namespace {
+   /// \brief
+   /// \param in
+   /// \param cursor The position in the source file where the identifier begins.
+   /// \returns
+   ///
+   std::string scan_floating_exponent(std::istream& in) noexcept(false)
+   {
+      if (auto c = in.peek(); std::toupper(c) == 'E') {
+         auto exponent = std::string{static_cast<char>(in.get())};
+
+         // an exponent may have one '+' or '-' after the 'E'
+         if (c = in.peek(); c == '+' or c == '-') {
+            exponent += static_cast<char>(in.get());
+         }
+
+         exponent += ltcpp::consume_istream_while(in, cjdb::isdigit);
+         return exponent;
+      }
+
+      return {};
+   }
+
+   /// \brief
+   /// \param in
+   /// \param cursor The position in the source file where the identifier begins.
+   /// \returns
+   ///
+   ltcpp::token scan_floating(std::istream& in, std::string&& number,
+      ltcpp::source_coordinate const cursor) noexcept(false)
+   {
+      constexpr auto is_floating_point_token = [](auto const x) constexpr noexcept {
+         return cjdb::isdigit(x) or x == '.';
+      };
+      number += ltcpp::consume_istream_while(in, is_floating_point_token);
+      number += ::scan_floating_exponent(in);
+      return ::ltcpp::make_token(std::move(number), cursor);
+   }
+} // namespace
+
+namespace ltcpp::detail_lexer {
+   /// \brief
+   /// \param in
+   /// \param cursor The position in the source file where the identifier begins.
+   /// \returns
+   ///
+   token scan_number(std::istream& in, source_coordinate const cursor) noexcept
+   {
+      auto number = ltcpp::consume_istream_while(in, cjdb::isdigit);
+      if (auto peek = in.peek(); peek == '.' or peek == 'e' or peek == 'E') {
+         return ::scan_floating(in, std::move(number), cursor);
+      }
+      else {
+         return ::ltcpp::make_token(std::move(number), cursor);
+      }
+   }
+
+   /// \brief Checks if a '.' forms a floating-point number or is indeed a dot.
+   ///
+   token possibly_float(std::istream& in, source_coordinate const cursor) noexcept
+   {
+      auto dot = static_cast<char>(in.get());
+      if (in and std::isdigit(in.peek())) {
+         return ::scan_floating(in, std::string{dot}, cursor);
+      }
+      else {
+         return ::ltcpp::make_token(std::string{dot}, cursor);
+      }
+   }
+} // namespace ltcpp::detail_lexer

--- a/source/lexer/scan_number.cpp
+++ b/source/lexer/scan_number.cpp
@@ -81,17 +81,4 @@ namespace ltcpp::detail_lexer {
          return ::ltcpp::make_token(std::move(number), cursor);
       }
    }
-
-   /// \brief Checks if a '.' forms a floating-point number or is indeed a dot.
-   ///
-   token possibly_float(std::istream& in, source_coordinate const cursor) noexcept
-   {
-      auto dot = static_cast<char>(in.get());
-      if (auto next = peek(in); next and std::isdigit(*next)) {
-         return ::scan_floating(in, std::string{dot}, cursor);
-      }
-      else {
-         return ::ltcpp::make_token(std::string{dot}, cursor);
-      }
-   }
 } // namespace ltcpp::detail_lexer

--- a/source/lexer/scan_string_literal.cpp
+++ b/source/lexer/scan_string_literal.cpp
@@ -30,12 +30,16 @@
 #include <range/v3/view/split.hpp>
 #include <string>
 #include <string_view>
+#include <iostream>
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/utility/iterator.hpp>
 
 namespace {
    using namespace ranges;
    using namespace std::string_view_literals;
 
    constexpr auto legal_escapes = R"(bfnrt\'")"sv;
+   constexpr auto escape_literals = "\b\f\n\r\t\\'\""sv;
 
    /// \brief A predicate that determines if two elements in a string are an escape sequence.
    ///
@@ -117,32 +121,7 @@ namespace {
       auto transform_escape = [](auto&& subrange) noexcept {
          Expects(distance(subrange) >= 2);
          auto& escape_char = *next(begin(subrange));
-         switch (escape_char) {
-         case 'b':
-            escape_char = '\b';
-            break;
-         case 'f':
-            escape_char = '\f';
-            break;
-         case 'n':
-            escape_char = '\n';
-            break;
-         case 'r':
-            escape_char = '\r';
-            break;
-         case 't':
-            escape_char = '\t';
-            break;
-         case '\'':
-            escape_char = '\'';
-            break;
-         case '\"':
-            escape_char = '\"';
-            break;
-         case '\\':
-            escape_char = '\\';
-            break;
-         }
+         escape_char = escape_literals[legal_escapes.find(escape_char)];
       };
 
       // the first subrange doesn't have any *legal* escapes, so we can just ignore it.

--- a/source/lexer/scan_string_literal.cpp
+++ b/source/lexer/scan_string_literal.cpp
@@ -1,0 +1,185 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "ltcpp/lexer/token.hpp"
+
+#include <cjdb/cctype/is_newline.hpp>
+#include <gsl/gsl>
+#include <istream>
+#include "ltcpp/consume_istream_while.hpp"
+#include "ltcpp/lexer/detail/scan_string_literal.hpp"
+#include <range/v3/action/adjacent_remove_if.hpp>
+#include <range/v3/algorithm/count.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/view/drop.hpp>
+#include <range/v3/view/drop_while.hpp>
+#include <range/v3/view/slice.hpp>
+#include <range/v3/view/split.hpp>
+#include <string>
+#include <string_view>
+
+namespace {
+   using namespace ranges;
+   using namespace std::string_view_literals;
+
+   constexpr auto legal_escapes = R"(bfnrt\'")"sv;
+
+   /// \brief A predicate that determines if two elements in a string are an escape sequence.
+   ///
+   /// This predicate is used to split on escape sequences.
+   /// \param first Iterator to the beginning of the range.
+   /// \param last Sentinel denoting the end of the range.
+   /// \returns A paired boolean and iterator to the backslash.
+   /// \note The return type is prescribed by split_view.
+   ///
+   auto is_escape = [](auto first, auto last) constexpr noexcept {
+      auto result = false;
+      if (auto next = ranges::next(first); next != last) {
+         result = *first == '\\' and legal_escapes.find(*next) != std::string_view::npos;
+      }
+
+      return std::make_pair(result, first);
+   };
+
+   /// \brief Checks each escape sequence is a legal escape sequence.
+   /// \returns `token_kind::string_literal` if all escape sequences are legal;
+   ///          `token_kind::ivalid_escape_sequence` otherwise.
+   ///
+   ltcpp::token_kind validate_escapes(std::string_view const lexeme) noexcept
+   {
+      auto no_illegal_escapes = [](auto&& x) constexpr noexcept {
+         // the first two characters need to be checked separately to the rest of the literal,
+         // because we get a false positive otherwise ("\\" has two backslashes, which immediately
+         // disqualifies it, if we were to bundle the first two characters together).
+         if (distance(x) >= 2 and x[0] == '\\' and legal_escapes.find(x[1]) == std::string_view::npos) {
+            return false;
+         }
+         else {
+            return count(x | view::drop(2), '\\') == 0;
+         }
+      };
+
+      auto invalid_escapes = lexeme
+                           | view::split(is_escape)
+                           | view::drop_while(no_illegal_escapes);
+
+      return empty(invalid_escapes) ? ltcpp::token_kind::string_literal
+                                    : ltcpp::token_kind::invalid_escape_sequence;
+   }
+
+   /// \brief Checks that the string literal is terminated by a close-quote and that all escape
+   ///        sequences are legal sequences.
+   /// \returns token_kind::string_literal if the string is well-formed;
+   ///          token_kind::unterminated_string_literal if it doesn't end with a close-quote;
+   ///          token_kind::invalid_escape_sequence otherwise.
+   ltcpp::token_kind validate_string_literal(std::string_view const lexeme) noexcept
+   {
+      // TODO: replace ends_with(lexeme, r2) with lexeme.ends_with(r2) when GCC 9 is released.
+      auto ends_with = [](auto const& r1, auto const& r2) {
+         return equal(r1 | view::drop(size(r1) - size(r2)), r2);
+      };
+      using namespace std::string_view_literals;
+      if (not ends_with(lexeme, "\""sv) or ends_with(lexeme, R"(\")"sv)) {
+         return ltcpp::token_kind::unterminated_string_literal;
+      }
+
+      // substr removes the enclosing quotes, which create noise.
+      return validate_escapes(lexeme.substr(1, size(lexeme) - 1));
+   }
+
+   /// \brief Erases the backslash preceding a checked escape sequence.
+   ///
+   void erase_backslashes(std::string& string_literal) noexcept
+   {
+      constexpr auto legal_escape = [](auto const x, auto const y) constexpr noexcept {
+         return x == '\\' and (std::iscntrl(y) or y == '\\' or y == '\"' or y == '\'');
+      };
+      string_literal |= action::adjacent_remove_if(legal_escape);
+   }
+
+   /// \brief Transforms escaped characters into their actual character representation.
+   ///
+   void generate_escapes(std::string& string_literal) noexcept
+   {
+      auto transform_escape = [](auto&& subrange) noexcept {
+         Expects(distance(subrange) >= 2);
+         auto& escape_char = *next(begin(subrange));
+         switch (escape_char) {
+         case 'b':
+            escape_char = '\b';
+            break;
+         case 'f':
+            escape_char = '\f';
+            break;
+         case 'n':
+            escape_char = '\n';
+            break;
+         case 'r':
+            escape_char = '\r';
+            break;
+         case 't':
+            escape_char = '\t';
+            break;
+         case '\'':
+            escape_char = '\'';
+            break;
+         case '\"':
+            escape_char = '\"';
+            break;
+         case '\\':
+            escape_char = '\\';
+            break;
+         }
+      };
+
+      // the first subrange doesn't have any *legal* escapes, so we can just ignore it.
+      auto escapes = string_literal | view::split(is_escape) | view::drop(1);
+      for_each(escapes, transform_escape);
+      erase_backslashes(string_literal);
+   }
+
+   std::string scan_string_literal(std::istream& in) noexcept
+   {
+      constexpr auto not_string_literal_sentinel = [](char const x) constexpr noexcept {
+         return not (x == '"' or cjdb::is_newline(x));
+      };
+
+      auto string_body = std::string{};
+      do {
+         string_body += static_cast<char>(in.get());
+         string_body += ltcpp::consume_istream_while(in, not_string_literal_sentinel);
+      } while (in.peek() == '"' and string_body.back() == '\\');
+
+      if (in.peek() == '"') {
+         string_body += static_cast<char>(in.get());
+      }
+      return string_body;
+   }
+} // namespace
+
+namespace ltcpp::detail_lexer {
+   using namespace ranges;
+
+   token scan_string_literal(std::istream& in, source_coordinate const cursor) noexcept
+   {
+      auto string_body = ::scan_string_literal(in);
+      auto const kind = ::validate_string_literal(string_body);
+      if (kind == token_kind::string_literal) {
+         ::generate_escapes(string_body);
+      }
+      return ltcpp::make_token(std::move(string_body), cursor, kind);
+   }
+} // namespace lexer::detail_lexer

--- a/source/lexer/scan_symbol.cpp
+++ b/source/lexer/scan_symbol.cpp
@@ -1,0 +1,60 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "ltcpp/lexer/detail/scan_symbol.hpp"
+#include "ltcpp/lexer/token.hpp"
+#include <istream>
+#include <string>
+
+namespace {
+   using ltcpp::token, ltcpp::source_coordinate, ltcpp::make_token;
+
+   /// \brief Checks if a character is the beginning of a multi-character token.
+   ///
+   token possibly_token(std::istream& in, char const current, source_coordinate const cursor,
+      std::string const& candidates) noexcept
+   {
+      if (auto peek = static_cast<char>(in.peek()); in and candidates.find(peek) != std::string::npos) {
+         in.get(peek);
+         return make_token(std::string{current, peek}, cursor);
+      }
+      else {
+         return make_token(std::string{current}, cursor);
+      }
+   }
+} // namespace
+
+namespace ltcpp::detail_lexer {
+   /// \brief
+   ///
+   token scan_symbol(std::istream& in, char const current, source_coordinate const cursor) noexcept
+   {
+      switch (current) {
+      case '+': [[fallthrough]];
+      case '-':
+         return ::possibly_token(in, current, cursor, {'=', current});
+      case '*': [[fallthrough]];
+      case '/': [[fallthrough]];
+      case '%': [[fallthrough]];
+      case '<': [[fallthrough]];
+      case '=': [[fallthrough]];
+      case '>': [[fallthrough]];
+      case '!':
+         return ::possibly_token(in, current, cursor, {'='});
+      default:
+         return ::ltcpp::make_token(std::string{current}, cursor);
+      }
+   }
+} // namespace ltcpp::detail_lexer

--- a/source/lexer/scan_symbol.cpp
+++ b/source/lexer/scan_symbol.cpp
@@ -18,17 +18,19 @@
 #include <istream>
 #include <string>
 
+#include "ltcpp/utility/peek.hpp"
+
 namespace {
-   using ltcpp::token, ltcpp::source_coordinate, ltcpp::make_token;
+   using ltcpp::token, ltcpp::source_coordinate, ltcpp::make_token, ltcpp::peek;
 
    /// \brief Checks if a character is the beginning of a multi-character token.
    ///
    token possibly_token(std::istream& in, char const current, source_coordinate const cursor,
-      std::string const& candidates) noexcept
+      std::string const& candidates) noexcept(false)
    {
-      if (auto peek = static_cast<char>(in.peek()); in and candidates.find(peek) != std::string::npos) {
-         in.get(peek);
-         return make_token(std::string{current, peek}, cursor);
+      if (auto next = peek(in); next and candidates.find(*next) != std::string::npos) {
+         in.get(*next);
+         return make_token(std::string{current, *next}, cursor);
       }
       else {
          return make_token(std::string{current}, cursor);
@@ -39,8 +41,10 @@ namespace {
 namespace ltcpp::detail_lexer {
    /// \brief
    ///
-   token scan_symbol(std::istream& in, char const current, source_coordinate const cursor) noexcept
+   token scan_symbol(std::istream& in, source_coordinate const cursor) noexcept(false)
    {
+      auto current = '\0';
+      in.get(current);
       switch (current) {
       case '+': [[fallthrough]];
       case '-':

--- a/source/lexer/scan_symbol.cpp
+++ b/source/lexer/scan_symbol.cpp
@@ -46,14 +46,10 @@ namespace ltcpp::detail_lexer {
       auto current = '\0';
       in.get(current);
       switch (current) {
-      case '+': [[fallthrough]];
       case '-':
-         return ::possibly_token(in, current, cursor, {'=', current});
-      case '*': [[fallthrough]];
-      case '/': [[fallthrough]];
-      case '%': [[fallthrough]];
-      case '<': [[fallthrough]];
-      case '=': [[fallthrough]];
+         return ::possibly_token(in, current, cursor, {">"});
+      case '<':
+         return ::possibly_token(in, current, cursor, {'=', '-'});
       case '>': [[fallthrough]];
       case '!':
          return ::possibly_token(in, current, cursor, {'='});

--- a/source/lexer/scan_whitespace.cpp
+++ b/source/lexer/scan_whitespace.cpp
@@ -206,8 +206,8 @@ namespace ltcpp::detail_lexer {
          in.unget(); // take_while consumes an extra character
       }
       else if (unterminated_comment) {
-         unterminated_comment->begin = cursor;
-         unterminated_comment->end = source_coordinate::shift(cursor, unterminated_comment->end);
+         unterminated_comment->begin(cursor);
+         unterminated_comment->end(source_coordinate::shift(cursor, unterminated_comment->end()));
          return tl::unexpected{*unterminated_comment};
       }
 

--- a/source/lexer/scan_whitespace.cpp
+++ b/source/lexer/scan_whitespace.cpp
@@ -26,7 +26,7 @@
 #include <range/v3/algorithm/adjacent_find.hpp>
 #include <range/v3/algorithm/count_if.hpp>
 #include <range/v3/numeric/accumulate.hpp>
-#include <range/v3/iterator_range.hpp>
+#include <range/v3/view/subrange.hpp>
 #include <range/v3/to_container.hpp>
 #include <range/v3/view/generate.hpp>
 #include <range/v3/view/take_while.hpp>
@@ -57,7 +57,7 @@ namespace ltcpp::detail_lexer {
    expected cursor_delta(std::string_view const code_points) noexcept
    {
       auto const reversed_code_points = code_points | view::reverse;
-      auto const last_line = iterator_range{
+      auto const last_line = subrange{
          adjacent_find(reversed_code_points, cjdb::is_newline).base(),
          end(code_points)
       };

--- a/source/lexer/scan_whitespace.cpp
+++ b/source/lexer/scan_whitespace.cpp
@@ -1,0 +1,203 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <cjdb/cctype/is_newline.hpp>
+#include <cjdb/cctype/is_printable.hpp>
+#include <cjdb/cctype/isspace.hpp>
+#include <cjdb/functional/rangecmp/partial_not_equal_to.hpp>
+#include <istream>
+#include "ltcpp/consume_istream_while.hpp"
+#include "ltcpp/lexer/detail/scan_whitespace.hpp"
+#include "ltcpp/irregular_transform.hpp"
+#include "ltcpp/source_coordinate.hpp"
+#include <range/v3/action/push_back.hpp>
+#include <range/v3/algorithm/adjacent_find.hpp>
+#include <range/v3/algorithm/count_if.hpp>
+#include <range/v3/numeric/accumulate.hpp>
+#include <range/v3/iterator_range.hpp>
+#include <range/v3/to_container.hpp>
+#include <range/v3/view/generate.hpp>
+#include <range/v3/view/take_while.hpp>
+#include <range/v3/view/reverse.hpp>
+#include <string_view>
+#include "tl/expected.hpp"
+
+namespace ltcpp::detail_lexer {
+   using namespace ranges;
+   using namespace std::string_literals;
+
+   enum class unexpected_whitespace { not_comment, unterminated_comment };
+   using expected = tl::expected<source_coordinate, unexpected_whitespace>;
+
+   /// \brief Given a string of UTF-8 coded characters, calculates the delta that a
+   ///        source_coordinate moves by.
+   ///
+   /// The source_coordinate line delta is increased by one for every occurrence of "\n" or "\f";
+   /// the source_coordinate column delta is increased by one for every printable character.
+   /// \param code_points A string of UTF-8 code points.
+   /// \returns A source_coordinate object containing the computed delta.
+   /// \note This function has linear complexity.
+   /// \note The algorithm used to find line separators is non-greedy.
+   ///
+   expected cursor_delta(std::string_view const code_points) noexcept
+   {
+      auto const reversed_code_points = code_points | view::reverse;
+      auto const last_line = iterator_range{
+         adjacent_find(reversed_code_points, cjdb::is_newline).base(),
+         end(code_points)
+      };
+      return expected{
+         source_coordinate{
+            source_coordinate::column_type{distance(last_line)},
+            source_coordinate::line_type{count_if(code_points, cjdb::is_newline)}
+         }
+      };
+   }
+
+   /// \brief Reads in all characters until the first non-whitespace character is encountered.
+   ///
+   /// Subsequent characters are not read by the stream.
+   /// \param in The stream to be read from.
+   /// \returns A source_coordinate delta indicating how many whitespace characters were read.
+   /// \note This function has linear complexity.
+   ///
+   expected scan_whitespace(std::istream& in, char space) noexcept
+   {
+      auto whitespace = consume_istream_while(in, cjdb::isspace);
+      return ::ltcpp::detail_lexer::cursor_delta(space + whitespace);
+   }
+
+   /// \brief Reads in all characters until the first newline character character is encountered.
+   ///
+   /// Subsequent characters are not read by the stream.
+   /// \param in The stream to be read from.
+   /// \returns A source_coordinate delta indicating how many characters were read.
+   /// \note This function has linear complexity.
+   ///
+   expected skip_single_line_comment(std::istream& in) noexcept
+   {
+      auto comment = consume_istream_while(in, std::not_fn(cjdb::is_newline));
+      return ::ltcpp::detail_lexer::cursor_delta("//" + comment);
+   }
+
+   /// \brief Reads in all characters until the first occurrence of the character sequence "*/".
+   ///
+   /// Subsequent characters are not read by the stream.
+   /// \param in The stream to be read from.
+   /// \returns A source_coordinate delta indicating how many characters were read.
+   ///
+   expected skip_multiline_comment(std::istream& in) noexcept
+   {
+      auto comment = "/*"s;
+      do {
+         action::push_back(
+            comment,
+            istream_range<char>(in) | view::take_while(cjdb::ranges::partial_not_equal_to{'*'})
+         );
+         comment += in.good() ? "*" : "";
+      } while (in and in.peek() != '/');
+
+      if (in) {
+         // take '/' from the stream or else it won't be consumed!
+         comment += static_cast<char>(in.get());
+      }
+
+      if (in) {
+         return ::ltcpp::detail_lexer::cursor_delta(comment);
+      }
+      else {
+         return tl::unexpected{unexpected_whitespace::unterminated_comment};
+      }
+   }
+
+   /// \brief Reads one single-line or multi-line comment.
+   /// \param in
+   /// \returns A source_coordinate object that contains the size of the comment if a comment is
+   ///          present; std::nullopt otherwise.
+   ///
+   expected skip_comment(std::istream& in) noexcept
+   {
+      if (auto c = '\0'; in.get(c) and c == '/') {
+         return ::ltcpp::detail_lexer::skip_single_line_comment(in);
+      }
+      else if (c == '*') {
+         return ::ltcpp::detail_lexer::skip_multiline_comment(in);
+      }
+      else { // this '/' wasn't the start of a comment
+         in.unget();
+         return tl::unexpected{unexpected_whitespace::not_comment};
+      }
+   }
+
+   /// \brief Reads all whitespace and comments until a non-whitespace, non-comment character is
+   ///        encountered.
+   ///
+   /// No subsequent characters are read.
+   ///
+   std::pair<source_coordinate, bool>
+   scan_whitespace_like(std::istream& in, source_coordinate cursor) noexcept
+   {
+      // Deduces if a single character is whitespace or a forward slash.
+      auto is_whitespaceish = [](auto const c) noexcept {
+         return cjdb::isspace(c) or c == '/';
+      };
+
+      // Dispatches to the comment scanner if the character is a forward slash and the whitespace
+      // scanner otherwise.
+      auto read_whitespaceish = [&in](auto const c) noexcept {
+         return (c == '/') ? ::ltcpp::detail_lexer::skip_comment(in)
+                           : ::ltcpp::detail_lexer::scan_whitespace(in, c);
+      };
+
+      // Deduces if the whitespaceish character was actually just a forward slash.
+      auto whitespace_confirmed = [](auto&& x) noexcept {
+         return x or x.error() == unexpected_whitespace::unterminated_comment;
+      };
+
+      // yucky state here
+      bool unterminated_comment = false;
+
+      // Transforms an expected object into a coordinate object.
+      // returns *coordinate if the value has been set; a source_coordinate equivalent to {0:0}
+      // otherwise.
+      // If the expected object's value has not been set, then the unterminated_comment flag is
+      // raised to indicate that we've reached an error state.
+      auto unwrap_coordinate = [&unterminated_comment](auto const coordinate) noexcept {
+         if (coordinate) {
+            return *coordinate;
+         }
+         else {
+            unterminated_comment = true;
+            return source_coordinate{
+               source_coordinate::column_type{0},
+               source_coordinate::line_type{0}
+            };
+         }
+      };
+
+      auto whitespace_distance = istream_range<char>(in)
+                               | view::take_while(is_whitespaceish)
+                               | ltcpp::irregular_transform(read_whitespaceish)
+                               | view::take_while(whitespace_confirmed)
+                               | ltcpp::irregular_transform(unwrap_coordinate);
+      cursor = accumulate(whitespace_distance, cursor, &source_coordinate::shift);
+
+      if (in) {
+         in.unget(); // take_while consumes an extra character
+      }
+
+      return {cursor, unterminated_comment};
+   }
+} // namespace ltcpp::detail_lexer

--- a/source/lexer/scan_whitespace.cpp
+++ b/source/lexer/scan_whitespace.cpp
@@ -108,7 +108,7 @@ namespace ltcpp::detail_lexer {
             istream_range<char>(in) | view::take_while(cjdb::ranges::partial_not_equal_to{'*'})
          );
          comment += in.good() ? "*" : "";
-      } while (in and in.peek() != '/');
+      } while (in.good() and in.peek() != '/');
 
       if (in) {
          // take '/' from the stream or else it won't be consumed!

--- a/source/lexer/token.cpp
+++ b/source/lexer/token.cpp
@@ -104,6 +104,7 @@ namespace {
          {"double", token_kind::double_},
          {"int",    token_kind::int_},
          {"string", token_kind::string_},
+         {"void",   token_kind::void_},
          // keywords
          {"break",    token_kind::break_},
          {"const",    token_kind::const_},

--- a/source/lexer/token.cpp
+++ b/source/lexer/token.cpp
@@ -142,8 +142,8 @@ namespace ltcpp {
    noexcept
    {
       auto const cursor_end = source_coordinate{
-         source_coordinate::column_type{ranges::distance(lexeme)},
-         source_coordinate::line_type{0} // lexemes don't span multiple lines
+         source_coordinate::line_type{0}, // lexemes don't span multiple lines
+         source_coordinate::column_type{ranges::distance(lexeme)}
       };
       return token{
          kind,

--- a/source/lexer/token.cpp
+++ b/source/lexer/token.cpp
@@ -1,0 +1,164 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY ltcpp::token_kind, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <cjdb/cctype/isalpha.hpp>
+#include <cjdb/cctype/isdigit.hpp>
+#include <gsl/gsl>
+#include "ltcpp/lexer/token.hpp"
+#include <range/v3/algorithm/count.hpp>
+#include <range/v3/distance.hpp>
+#include <string_view>
+#include <unordered_map>
+
+namespace {
+   using namespace ranges;
+
+   /// \brief
+   /// \param lexeme
+   /// \returns
+   ///
+   ltcpp::token_kind deduce_number_kind(std::string_view const lexeme) noexcept
+   {
+      auto result = ltcpp::token_kind::integral_literal;
+      auto const has_exponent = [](auto const l) noexcept {
+         return l.find('E') != std::string_view::npos or l.find('e') != std::string_view::npos;
+      };
+      if (auto radix_point = count(lexeme, '.'); radix_point == 1 or has_exponent(lexeme)) {
+         result = ltcpp::token_kind::floating_literal;
+      }
+      else if (radix_point > 1) {
+         return ltcpp::token_kind::too_many_radix_points;
+      }
+
+      if (not cjdb::isdigit(lexeme.back()) and lexeme.back() != '.') {
+         return ltcpp::token_kind::exponent_lacking_digit;
+      }
+      return result;
+   }
+
+   /// \brief
+   /// \param lexeme
+   /// \returns
+   ///
+   ltcpp::token_kind lookup_kind(std::string_view const lexeme) noexcept
+   {
+      Expects(not empty(lexeme));
+
+      using ltcpp::token_kind;
+      static auto lexeme_table = std::unordered_map<std::string_view, token_kind>{
+         // symbols
+         {"++", token_kind::increment},
+         {"--", token_kind::decrement},
+         // arithmetic
+         {"+", token_kind::plus},
+         {"-", token_kind::minus},
+         {"*", token_kind::times},
+         {"/", token_kind::divide},
+         {"%", token_kind::modulo},
+         // assignment
+         {"=",  token_kind::assign},
+         {"+=", token_kind::plus_eq},
+         {"-=", token_kind::minus_eq},
+         {"*=", token_kind::times_eq},
+         {"/=", token_kind::divide_eq},
+         {"%=", token_kind::modulo_eq},
+         // separators
+         {".", token_kind::dot},
+         {",", token_kind::comma},
+         {";", token_kind::semicolon},
+         {"{", token_kind::brace_open},
+         {"}", token_kind::brace_close},
+         {"(", token_kind::paren_open},
+         {")", token_kind::paren_close},
+         {"[", token_kind::square_open},
+         {"]", token_kind::square_close},
+         // comparison operations
+         {"==", token_kind::equal_to},
+         {"!=", token_kind::not_equal_to},
+         {"<",  token_kind::less},
+         {"<=", token_kind::less_equal},
+         {">=", token_kind::greater_equal},
+         {">",  token_kind::greater},
+         // logical operators
+         {"and", token_kind::and_},
+         {"or",  token_kind::or_},
+         {"not", token_kind::not_},
+         // boolean literals
+         {"false", token_kind::boolean_literal},
+         {"true",  token_kind::boolean_literal},
+         // types
+         {"bool",   token_kind::bool_},
+         {"char",   token_kind::char_},
+         {"double", token_kind::double_},
+         {"int",    token_kind::int_},
+         {"string", token_kind::string_},
+         // keywords
+         {"break",    token_kind::break_},
+         {"const",    token_kind::const_},
+         {"continue", token_kind::continue_},
+         {"for",      token_kind::for_},
+         {"if",       token_kind::if_},
+         {"return",   token_kind::return_},
+         {"while",    token_kind::while_},
+         // errors
+         {"!", token_kind::unknown_token}
+      };
+
+      if (auto result = lexeme_table.find(lexeme); result != end(lexeme_table)) {
+         return result->second;
+      }
+      else if (auto const front = lexeme.front(); cjdb::isalpha(front) or front == '_') {
+         return ltcpp::token_kind::identifier;
+      }
+      else if (cjdb::isdigit(front) or front == '.') {
+         return deduce_number_kind(lexeme);
+      }
+      else {
+         return ltcpp::token_kind::unknown_token;
+      }
+   }
+} // namespace
+
+namespace ltcpp {
+   /// \brief Given a lexeme and a source coordinate, generates a token.
+   /// \param lexeme A UTF-8 string that forms a valid sequence of characters.
+   /// \param cursor The position in the source file where the lexeme begins.
+   /// \param kind
+   /// \returns A token, based on the lexeme provided.
+   ///
+   token make_token(std::string lexeme, source_coordinate const cursor_begin, token_kind const kind)
+   noexcept
+   {
+      auto const cursor_end = source_coordinate{
+         source_coordinate::column_type{ranges::distance(lexeme)},
+         source_coordinate::line_type{0} // lexemes don't span multiple lines
+      };
+      return token{
+         kind,
+         std::move(lexeme),
+         cursor_begin,
+         source_coordinate::shift(cursor_begin, cursor_end)
+      };
+   }
+   /// \brief Given a lexeme and a source coordinate, generates a token.
+   /// \param lexeme A UTF-8 string that forms a valid sequence of characters.
+   /// \param cursor The position in the source file where the lexeme begins.
+   /// \returns A token, based on the lexeme provided.
+   ///
+   token make_token(std::string lexeme, source_coordinate const cursor_begin) noexcept
+   {
+      return make_token(std::move(lexeme), cursor_begin, lookup_kind(lexeme));
+   }
+} // namespace ltcpp

--- a/source/lexer/token.cpp
+++ b/source/lexer/token.cpp
@@ -58,9 +58,6 @@ namespace {
 
       using ltcpp::token_kind;
       static auto lexeme_table = std::unordered_map<std::string_view, token_kind>{
-         // symbols
-         {"++", token_kind::increment},
-         {"--", token_kind::decrement},
          // arithmetic
          {"+", token_kind::plus},
          {"-", token_kind::minus},
@@ -68,15 +65,11 @@ namespace {
          {"/", token_kind::divide},
          {"%", token_kind::modulo},
          // assignment
-         {"=",  token_kind::assign},
-         {"+=", token_kind::plus_eq},
-         {"-=", token_kind::minus_eq},
-         {"*=", token_kind::times_eq},
-         {"/=", token_kind::divide_eq},
-         {"%=", token_kind::modulo_eq},
+         {"<-", token_kind::assign},
          // separators
          {".", token_kind::dot},
          {",", token_kind::comma},
+         {":", token_kind::colon},
          {";", token_kind::semicolon},
          {"{", token_kind::brace_open},
          {"}", token_kind::brace_close},
@@ -84,8 +77,9 @@ namespace {
          {")", token_kind::paren_close},
          {"[", token_kind::square_open},
          {"]", token_kind::square_close},
+         {"->", token_kind::arrow},
          // comparison operations
-         {"==", token_kind::equal_to},
+         {"=", token_kind::equal_to},
          {"!=", token_kind::not_equal_to},
          {"<",  token_kind::less},
          {"<=", token_kind::less_equal},
@@ -99,20 +93,32 @@ namespace {
          {"false", token_kind::boolean_literal},
          {"true",  token_kind::boolean_literal},
          // types
-         {"bool",   token_kind::bool_},
-         {"char",   token_kind::char_},
-         {"double", token_kind::double_},
-         {"int",    token_kind::int_},
-         {"string", token_kind::string_},
-         {"void",   token_kind::void_},
+         {"bool",    token_kind::bool_},
+         {"char8",   token_kind::char8},
+         {"float16", token_kind::float16},
+         {"float32", token_kind::float32},
+         {"float64", token_kind::float64},
+         {"int8",    token_kind::int8},
+         {"int16",   token_kind::int16},
+         {"int32",   token_kind::int32},
+         {"int64",   token_kind::int64},
+         {"void",    token_kind::void_},
          // keywords
+         {"assert",   token_kind::assert_},
          {"break",    token_kind::break_},
-         {"const",    token_kind::const_},
          {"continue", token_kind::continue_},
          {"for",      token_kind::for_},
+         {"fun",      token_kind::fun_},
          {"if",       token_kind::if_},
+         {"import",   token_kind::import_},
+         {"let",      token_kind::let_},
+         {"module",   token_kind::module_},
+         {"mutable",  token_kind::mutable_},
+         {"readable", token_kind::readable_},
+         {"ref",      token_kind::ref_},
          {"return",   token_kind::return_},
          {"while",    token_kind::while_},
+         {"writable", token_kind::writable_},
          // errors
          {"!", token_kind::unknown_token}
       };


### PR DESCRIPTION
This commit implements the ltcpp lexer using ranges. This implementation
will be contrasted against the implementation in lexer-no-ranges in an
upcoming blog.